### PR TITLE
Allow for extranous characters in IP addresses

### DIFF
--- a/src/main/java/org/lable/oss/bitsandbytes/IPAddress4.java
+++ b/src/main/java/org/lable/oss/bitsandbytes/IPAddress4.java
@@ -44,6 +44,8 @@ public class IPAddress4 extends IPAddress {
      */
     public static IPAddress4 parse(String address) {
         if (address == null) throw new IllegalArgumentException("Address may not be null.");
+        address = trimNonIPChars(address);
+
         String[] parts = address.split("\\.");
         if (parts.length > 4) throw new IllegalArgumentException("Unrecognized notation: " + address);
 
@@ -95,6 +97,28 @@ public class IPAddress4 extends IPAddress {
      */
     public int getInt() {
         return address;
+    }
+
+    static String trimNonIPChars(String ip) {
+        int start = 0;
+        int len = ip.length();
+        int end = len;
+
+        for (int i = 0; i < len; i++) {
+            if (isIPChar(ip.charAt(i))) break;
+            start++;
+        }
+
+        for (int i = len - 1; i >= start; i--) {
+            if (isIPChar(ip.charAt(i))) break;
+            end--;
+        }
+
+        return start > 0 && end < len ? ip.substring(start, end) : ip;
+    }
+
+    static boolean isIPChar(char c) {
+        return c == '.' || (c >= '0' && c <= '9');
     }
 
     @Override

--- a/src/main/java/org/lable/oss/bitsandbytes/IPAddress6.java
+++ b/src/main/java/org/lable/oss/bitsandbytes/IPAddress6.java
@@ -50,6 +50,8 @@ public class IPAddress6 extends IPAddress {
      */
     public static IPAddress6 parse(String address) {
         if (address == null) throw new IllegalArgumentException("Address may not be null.");
+        address = trimNonIPChars(address);
+
         int[] blocks = new int[8];
         int currentBlock = 0;
         int i;
@@ -277,5 +279,30 @@ public class IPAddress6 extends IPAddress {
             if (hex.charAt(i) != '0') return hex.substring(i);
         }
         return hex.substring(3);
+    }
+
+    static String trimNonIPChars(String ip) {
+        int start = 0;
+        int len = ip.length();
+        int end = len;
+
+        for (int i = 0; i < len; i++) {
+            if (isIPChar(ip.charAt(i))) break;
+            start++;
+        }
+
+        for (int i = len - 1; i >= start; i--) {
+            if (isIPChar(ip.charAt(i))) break;
+            end--;
+        }
+
+        return start > 0 && end < len ? ip.substring(start, end) : ip;
+    }
+
+    static boolean isIPChar(char c) {
+        return c == ':' || c == '.'
+                || (c >= '0' && c <= '9')
+                || (c >= 'a' && c <= 'z')
+                || (c >= 'A' && c <= 'Z');
     }
 }

--- a/src/test/java/org/lable/oss/bitsandbytes/IPAddress4Test.java
+++ b/src/test/java/org/lable/oss/bitsandbytes/IPAddress4Test.java
@@ -39,7 +39,12 @@ public class IPAddress4Test {
         assertThat(IPAddress4.parse("0.0.0.1").address, is(1));
 
         assertThat(IPAddress4.parse("1.0.0.0").address, is(16777216));
+
         assertThat(IPAddress4.parse("127.0.255.250").address, is(2130771962));
+        assertThat(IPAddress4.parse(" 127.0.255.250 ").address, is(2130771962));
+        assertThat(IPAddress4.parse("[127.0.255.250]").address, is(2130771962));
+        assertThat(IPAddress4.parse(" [127.0.255.250] ").address, is(2130771962));
+
         assertThat(IPAddress4.parse("127.65530"), is(IPAddress4.parse("127.0.255.250")));
     }
 

--- a/src/test/java/org/lable/oss/bitsandbytes/IPAddress6Test.java
+++ b/src/test/java/org/lable/oss/bitsandbytes/IPAddress6Test.java
@@ -54,6 +54,12 @@ public class IPAddress6Test {
         assertThat(IPAddress6.parse("::ffff:192.0.2.128").high, is(0L));
         assertThat(IPAddress6.parse("::ffff:192.0.2.128").low, is(281473902969472L));
         assertThat(IPAddress6.parse("::ffff:192.0.2.128").toString(), is("::ffff:c000:280"));
+        assertThat(IPAddress6.parse(" ::ffff:192.0.2.128 ").high, is(0L));
+        assertThat(IPAddress6.parse(" ::ffff:192.0.2.128 ").low, is(281473902969472L));
+        assertThat(IPAddress6.parse(" ::ffff:192.0.2.128 ").toString(), is("::ffff:c000:280"));
+        assertThat(IPAddress6.parse(" [::ffff:192.0.2.128] ").high, is(0L));
+        assertThat(IPAddress6.parse(" [::ffff:192.0.2.128] ").low, is(281473902969472L));
+        assertThat(IPAddress6.parse(" [::ffff:192.0.2.128] ").toString(), is("::ffff:c000:280"));
 
         // Round-trip.
         assertThat(IPAddress6.parse("fe80::b336:6660:c18a:6903").toString(), is("fe80::b336:6660:c18a:6903"));


### PR DESCRIPTION
This makes `parse` more flexible, when the input contains somthing like `[0:0:0:0:0:0:0:1]`. Brackets are sometimes added to delimit IPv6 addresses from a subsequent port number.